### PR TITLE
Własna hashmapa

### DIFF
--- a/src/main/java/org/example/HashMapOwn.java
+++ b/src/main/java/org/example/HashMapOwn.java
@@ -1,0 +1,133 @@
+package org.example;
+
+import java.util.Arrays;
+
+public class HashMapOwn<K, V extends String> implements OwnMap {
+
+    private int length = 16;
+    private int newLength = length * 2;
+    private KeyValue<K, V>[] hashArr;
+    private int pointer = 0;
+
+    public HashMapOwn() {
+        hashArr = new KeyValue[length];
+    }
+
+    @Override
+    public boolean put(String key, String value) {
+        if (key == null) {
+            throw new RuntimeException("Illegal key: " + key);
+        }
+        if (pointer == hashArr.length - 1) {
+            resize(newLength);
+        }
+        int index = hashing(key);
+        KeyValue<K, V> newPair = new KeyValue<>(key, value);
+        KeyValue<K, V> pair = hashArr[index];
+        if (pair == null) {
+            hashArr[index] = newPair;
+        } else {
+            while (pair != null) {
+                if (pair.getKey().equals(key)) {
+                    pair.setValue(value);
+                    break;
+                }
+            }
+            if (pair.next != null) {
+                pair = pair.next;
+            } else {
+                pair.next = newPair;
+            }
+        }
+        pointer++;
+        return true;
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        int index = hashing(key);
+        KeyValue<K, V> pair = hashArr[index];
+        while (pair != null) {
+            if (pair.getKey().equals(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        for (int i = hashArr.length; i-- > 0; ) {
+            for (KeyValue<K, V> pair = hashArr[i]; pair != null; pair = pair.next) {
+                if (pair.getValue().equals(value)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String remove(String key) {
+        if (pointer != 0) {
+            int index = hashing(key);
+            KeyValue<K, V> pair = hashArr[index];
+            KeyValue<K, V> previous = null;
+            while (pair != null) {
+                if (pair.getKey().equals(key)) {
+                    if (previous != null) {
+                        previous.next = pair.next;
+                    } else {
+                        previous = pair.next;
+                        hashArr[index] = previous;
+                    }
+                    pointer--;
+                    return pair.getValue();
+                }
+                previous = pair;
+                pair = pair.next;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String get(String key) {
+        if (key == null) {
+            return null;
+        }
+        int index = hashing(key);
+        KeyValue<K, V> pair = hashArr[index];
+        while (pair != null) {
+            if (pair.getKey().equals(key)) {
+                return pair.getValue();
+            }
+            pair = pair.next;
+        }
+        return null;
+    }
+
+    public int size() {
+        return pointer;
+    }
+
+    public void resize(int newLength) {
+        hashArr = Arrays.copyOf(hashArr, newLength);
+    }
+
+    public int hashing(String key) {
+        int i = key.hashCode();
+        int hash = (key == null) ? 0 : i;
+        int index = hash & (hashArr.length - 1);
+        return index;
+    }
+
+    public void print() {
+        for (int i = hashArr.length; i-- > 0; ) {
+            for (KeyValue<K, V> pair = hashArr[i]; pair != null; pair = pair.next) {
+                System.out.println(pair.getKey() + " " + pair.getValue());
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/example/KeyValue.java
+++ b/src/main/java/org/example/KeyValue.java
@@ -1,0 +1,43 @@
+package org.example;
+
+public class KeyValue<K,V> {
+    private String key;
+    private String value;
+    KeyValue<K, V> next;
+
+    public KeyValue(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        KeyValue other = (KeyValue) obj;
+        if (key != other.getKey())
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return key.hashCode();
+    }
+}

--- a/src/main/java/org/example/OwnMap.java
+++ b/src/main/java/org/example/OwnMap.java
@@ -1,0 +1,21 @@
+package org.example;
+
+public interface OwnMap {
+
+    boolean put(String key, String value);
+    boolean containsKey(String key);
+    boolean containsValue(Object value);
+
+    /**
+     * @param key
+     *  key for which (key, value) entry will be removed
+     *
+     * @return value for given key
+     */
+    String remove(String key);
+
+    /**
+     * Return value for given key
+     */
+    String get(String key);
+}

--- a/src/test/java/org/example/HashMapOwnTest.java
+++ b/src/test/java/org/example/HashMapOwnTest.java
@@ -1,0 +1,151 @@
+package org.example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HashMapOwnTest {
+    HashMapOwn<String, String> map = new HashMapOwn<>();
+
+    @Test
+    void mustPutElement() {
+        //given
+        map.put("key120", "Bob");
+        map.put("key121", "Tom");
+        map.put("key122", "Dev");
+        map.put("key123", "Sam");
+
+        //when
+        map.print();
+
+        //then
+        Assertions.assertEquals("Bob", map.get("key120"));
+        Assertions.assertEquals("Tom", map.get("key121"));
+        Assertions.assertEquals("Dev", map.get("key122"));
+        Assertions.assertEquals("Sam", map.get("key123"));
+
+        System.out.println("getValue from \"key120\" = " + map.get("key120"));
+        System.out.println("getValue from \"key121\" = " + map.get("key121"));
+        System.out.println("getValue from \"key122\" = " + map.get("key122"));
+        System.out.println("getValue from \"key123\" = " + map.get("key123"));
+    }
+
+    @Test
+    void mustContainsKeyThenTrue_whenKeyWrongThenFalse() {
+        //given
+        map.put("key120", "Bob");
+        map.put("key121", "Tom");
+        map.put("key122", "Dev");
+        map.put("key123", "Sam");
+
+        //when
+        map.print();
+
+        //then
+        Assertions.assertTrue(map.containsKey("key120"));
+        Assertions.assertTrue(map.containsKey("key121"));
+        Assertions.assertTrue(map.containsKey("key122"));
+        Assertions.assertTrue(map.containsKey("key123"));
+        Assertions.assertFalse(map.containsKey("key125"));
+
+        System.out.println("containsKey \"key120\" " + map.containsKey("key120"));
+        System.out.println("containsKey \"key121\" " + map.containsKey("key121"));
+        System.out.println("containsKey \"key122\" " + map.containsKey("key122"));
+        System.out.println("containsKey \"key123\" " + map.containsKey("key123"));
+        System.out.println("containsKey \"key125\" " + map.containsKey("key125"));
+    }
+
+    @Test
+    void mustContainsValueThenTrue_whenValueWrongThenFalse() {
+        //given
+        map.put("key120", "Bob");
+        map.put("key121", "Tom");
+        map.put("key122", "Dev");
+        map.put("key123", "Sam");
+
+        //when
+        map.print();
+
+        //then
+        Assertions.assertTrue(map.containsValue("Bob"));
+        Assertions.assertTrue(map.containsValue("Tom"));
+        Assertions.assertTrue(map.containsValue("Dev"));
+        Assertions.assertTrue(map.containsValue("Sam"));
+        Assertions.assertFalse(map.containsValue("Mary"));
+
+        System.out.println("containsValue \"Bob\" " + map.containsValue("Bob"));
+        System.out.println("containsValue \"Tom\" " + map.containsValue("Tom"));
+        System.out.println("containsValue \"Dev\" " + map.containsValue("Dev"));
+        System.out.println("containsValue \"Sam\" " + map.containsValue("Sam"));
+        System.out.println("containsValue \"Mary\" " + map.containsValue("Mary"));
+    }
+
+    @Test
+    void mustRemoveElementWhenKeyAreInMapShouldReturnValue_whenKeyWrongReturnNull() {
+        //given
+        map.put("key120", "Bob");
+        map.put("key121", "Tom");
+        map.put("key122", "Dev");
+        map.put("key123", "Sam");
+
+        //when
+        map.print();
+
+        //then
+        Assertions.assertEquals("Tom", map.get("key121"));
+        Assertions.assertEquals("Sam", map.get("key123"));
+        Assertions.assertNull(null, map.get("key121"));
+
+        System.out.println("remove \"key121\" and getValue = " + map.remove("key121"));
+        System.out.println("remove \"key123\" and getValue = " + map.remove("key123"));
+        System.out.println("remove \"key121\" and getValue = " + map.remove("key121"));
+    }
+
+    @Test
+    void mustGetElementReturnValueForGivenKey() {
+        //given
+        map.put("key120", "Bob");
+        map.put("key121", "Tom");
+        map.put("key122", "Dev");
+        map.put("key123", "Sam");
+
+        //when
+        map.print();
+
+        //then
+        Assertions.assertEquals("Bob", map.get("key120"));
+        Assertions.assertEquals("Tom", map.get("key121"));
+        Assertions.assertEquals("Dev", map.get("key122"));
+        Assertions.assertEquals("Sam", map.get("key123"));
+
+        System.out.println("getValue from \"key120\" = " + map.get("key120"));
+        System.out.println("getValue from \"key121\" = " + map.get("key121"));
+        System.out.println("getValue from \"key122\" = " + map.get("key122"));
+        System.out.println("getValue from \"key123\" = " + map.get("key123"));
+    }
+
+    @Test
+    void mustGiveExceptionWhenKeyWrong() {
+        //given
+        map.put("key120", "Bob");
+        map.put("key121", "Tom");
+        map.put("key122", "Dev");
+        map.put("key123", "Sam");
+        boolean expected = true;
+
+
+        //when
+        map.print();
+        try {
+            System.out.println("getValue from \"key125\" = " + map.get("key125"));
+        } catch (NullPointerException e) {
+            e.getMessage();
+            expected = false;
+        }
+
+        //then
+        Assertions.assertTrue(expected);
+    }
+
+}


### PR DESCRIPTION
Zaimplementuj własną hashmapę bazując na danym interfejsie:
public interface OwnMap {
  boolean put(String key, String value);
  boolean containsKey(String key);
  boolean containsValue(Object value);
  /**
   * @param key
   *  key for which (key, value) entry will be removed
   *
   * @return value for given key
   */
  String remove(String key);
  /**
   * Return value for given key
   */
  String get(String key);
}
Założenia dodatkowe:
●      Mapa przyjmuje tylko typ String
●      nie zachodzi kolizja w mapie tzn. wartość pod zadanym kluczem jest nadpisywana
●      złożoność obliczeniowa nie gra dużej roli, ale warto zwrócić na nią uwagę
●      do implementacji nie wolno stosować jakiejkolwiek implementacji już istniejącej Mapy
●      implementacja powinna być pokryta testami